### PR TITLE
Subgraph Tool v0

### DIFF
--- a/module/queries/graph.py
+++ b/module/queries/graph.py
@@ -15,9 +15,9 @@ class Graph:
         """
         if g and pickle_path:
             raise ValueError("only provide either g or pickle_path, not both.")
-        if pickle_path:
+        if pickle_path is not None:
             self.load_graph_from_pickle(pickle_path)
-        elif g:
+        elif g is not None:
             self.G = g
         else:
             print("Building graph from local files, please wait for success message...")
@@ -54,6 +54,18 @@ class Graph:
                     if instance2_id not in self.G:
                         self.G.add_node(instance2_id, instance_label=instance2_label.strip(), concept_id=concept2_id.strip())
                     self.G.add_edge(instance1_id, instance2_id, relation_id=relation_id)
+
+    def get_all_nodes(self):
+        """
+        :return: set of all node ids in graph
+        """
+        return set(self.G.nodes())
+
+    def get_all_edges(self):
+        """
+        :return: set of all edges in graph. Each edge is tuple of (src_node_id, dest_node_id, relation_id)
+        """
+        return set(self.G.edges(data="relation_id"))
 
     def save_graph_to_pickle(self, pickle_path):
         """
@@ -144,7 +156,7 @@ class Graph:
             view = self.G[instance1_id][instance2_id]
             return [view[key]['relation_id'] for key in view]
 
-    def get_edges(self, instance1_id, instance2_id):
+    def get_edges_between(self, instance1_id, instance2_id):
         """
         Gets a list of relation_ids between instance1 and instance2 regardless of direction.
         :param instance1_id: id of instance1

--- a/module/queries/graph_utils.py
+++ b/module/queries/graph_utils.py
@@ -23,27 +23,52 @@ def get_graph(pickle_path=GRAPH_PICKLE_PATH):
     return g
 
 
-def save_all_node_names_ids_json(g):
+def save_all_node_names_ids_json(g, out_path="all_node_names_ids.json"):
     """
     Writes a dictionary of all nodes to json file, {instance_label:instance_id}
+    :param out_path: (string) path to write json file
     :param g: (Graph) BGV backend graph.
     :return: None
     """
     json_string = json.dumps({g.get_instance_label(node): node for node in g})
-    with open("all_node_names_ids.json", "w") as f:
+    with open(out_path, "w") as f:
         f.write(json_string)
-    print("Saved all node names and ids to all_node_names_ids.json")
+    print("Saved all node names and ids to {}".format(out_path))
 
 
-def save_all_concept_names_ids_json():
+def save_all_concept_names_ids_json(out_path="all_concept_names_ids.json"):
     """
     Writes a dictionary of all concepts to json file, {concept_label:concept_id}
+    :param out_path: (string) path to write json file
     :return: None
     """
     json_string = json.dumps(CONCEPT_LABEL_ID_DICT)
-    with open("all_concept_names_ids.json", "w") as f:
+    with open(out_path, "w") as f:
         f.write(json_string)
-    print("Saved all concept names and ids to all_concpet_names_ids.json")
+    print("Saved all concept names and ids to {}".format(out_path))
+
+
+def graph_to_dict(g):
+    """
+    Encodes a Graph in web-friendly dictionary format.
+    :param g: (Graph) BGV backend Graph
+    :return: (dict) graph_dict contains web-friendly information about nodes and edges
+    """
+    node_dicts = []
+    for node in g:
+        node_info = g.get_node(node)
+        node_dict = {'qid': node, 'label': node_info['instance_label'],
+                     'domain': CONCEPT_ID_LABEL_DICT[node_info['concept_id']]}
+        node_dicts.append(node_dict)
+
+    link_dicts = []
+    for src_node_id, dst_node_id, relation_id in g.get_all_edges():
+        link_dict = {'target': dst_node_id, 'source': src_node_id,
+                     'weight': 0.01, 'label': RELATION_ID_LABEL_DICT[relation_id]}
+        link_dicts.append(link_dict)
+
+    graph_dict = {'nodes': node_dicts, 'links': link_dicts}
+    return graph_dict
 
 
 def get_subgraph_k_hops_around_node(g, instance_id, k):
@@ -76,3 +101,65 @@ def get_subgraph_k_hops_around_node(g, instance_id, k):
                 for child_id in g.get_node_neighbors(curr_id):
                     q.append((child_id, curr_k+1))
     return g.get_subgraph(visited), k_count_dict
+
+
+def get_subgraph_k_hops_around_node_concept_type(g, instance_id, concept_id, k, max_results):
+    """
+    Performs BFS starting at node corresponding to instance_id, and returns subgraph with all neighbors
+    of node within k hops of type concept_id. Subgraph also includes all nodes on the path between
+    instance_id and the ending nodes of type concept_id.
+    :param g: (Graph) BGV backend Graph
+    :param instance_id: (string) id of node around which to build subgraph
+    :param concept_id: (string) id of concept in which to end paths with
+    :param k: (string) number of hops around instance_id of node to include in subgraph
+    :param max_results: (int) maximum number of leaf nodes of type concept_id to present
+    :return: (Graph) subgraph with all neighbors of node within k hops
+    :return: (list[tuples]) target_concept_results holds a list of tuples containing all visited nodes
+                            of type concept_id, as well as the path_length from instance_id
+    """
+
+    q = [([instance_id], 0)]
+    visited = set()
+    subgraph_nodes = set()
+    target_concept_results = list()
+
+    while len(q) > 0:
+        curr_path, curr_k = q.pop(0)
+        curr_id = curr_path[-1]
+
+        if curr_id not in visited:
+            visited.add(curr_id)
+
+            if g.get_concept_id(curr_id) == concept_id:  # encountered desired concept
+                if len(target_concept_results) < max_results:
+                    subgraph_nodes.update(curr_path)  # add all nodes in this path to our subgraph
+                    target_concept_results.append((curr_id, curr_k))
+                else:  # if reached max_results, return
+                    return g.get_subgraph(subgraph_nodes), target_concept_results
+
+            if curr_k < k:
+                for child_id in g.get_node_neighbors(curr_id):
+                    q.append((curr_path + [child_id], curr_k+1))
+
+    return g.get_subgraph(subgraph_nodes), target_concept_results
+
+
+def subgraph_tool(instance_id, concept_id, k, max_results=100):
+    """
+    Given a starting node, an ending node type, and number of hops, return subgraph in json dictionary form.
+    :param instance_id: (string) starting node id
+    :param concept_id: (string) id of type/domain/concept of ending node
+    :param k: (int) maximum number of hops from starting node to explore
+    :param max_results: (int) maximum number of leaf nodes of type concept_id to present
+    :return: (dict) contains results list and subgraph
+    """
+    concept_label = CONCEPT_ID_LABEL_DICT[concept_id]
+    g = get_graph()
+    subg, target_concept_results = get_subgraph_k_hops_around_node_concept_type(g, instance_id, concept_id, k, max_results)
+    graph_dict = graph_to_dict(subg)
+    results_list = list()
+    for node_id, path_length in target_concept_results:
+        result_dict = {'name': g.get_instance_label(node_id), 'domain': concept_label, 'path_length': path_length}
+        results_list.append(result_dict)
+    json_dict = {'results': results_list, 'graph': graph_dict}
+    return json_dict


### PR DESCRIPTION
minor edits to graph class (added functionality of returning all nodes and all edges)
`subgraph_tool` function, which calls `get_subgraph_k_hops_around_node_concept_typ`e (performs BFS), and `graph_to_dict` (store graph as dict)

Web application can directly call `subgraph_tool(instance_id, concept_id, k, max_results=100)` to get dictionary

Closes #14 
Closes #16 
Closes #53 