### PR TITLE
DrugBank nearest neighbor sensitivity test

### DIFF
--- a/module/similarity_tool/tests/test_drugbrank.py
+++ b/module/similarity_tool/tests/test_drugbrank.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pandas as pd 
+import argparse
+import itertools
+import tqdm
+import os
+import sys
+sys.path.append(os.getcwd())
+
+from collections import defaultdict
+from module.similarity_tool.nearest_neighbors import NearestNeighbors
+
+
+EMBEDDING_TYPES = ['relation', 'stranse', 'node2vec']
+AGGREGATION_METHOD =['majority', 'nearest', 'mean']
+DISTANCE_METRIC = ['cos', 'l1', 'l2']
+
+
+def main(args):
+
+    # parse in drugbrank csv
+    df = pd.read_csv(args.drugbank_csv)
+    MEDICAL_CONDITIONS = df.MedicalCondition.unique().tolist()
+
+    # define test conditions
+    test_conditions = [
+        EMBEDDING_TYPES, 
+        AGGREGATION_METHOD,
+        DISTANCE_METRIC, 
+        MEDICAL_CONDITIONS
+    ]
+    test_cases = list(itertools.product(*test_conditions))
+
+    # results dictionary to be converted to dataframe
+    results = defaultdict(list)
+
+    # loop over different test parameters
+    for emb_type, agg_meth, dist_metr, med_cond in tqdm.tqdm(test_cases):
+
+        # generate train/test split
+        df_cond = df[df.MedicalCondition == med_cond]
+        targets = df_cond[df_cond.Split == "Train"].WikidataID.tolist()
+        true_neighbors = df_cond[df_cond.Split == "Test"].WikidataID.tolist()
+
+        # choose number of neighbors to retrieve
+        if args.num_neighbors is None:
+            num_neighbors = len(true_neighbors)
+        else:
+            num_neighbors = args.num_neighbors
+
+        # skip test condition if no test case exist 
+        if num_neighbors == 0:
+            continue
+
+        # create nearest neighbor class
+        nn = NearestNeighbors(
+            targets = targets, 
+            #emb_file_path = args.emb_file_path, 
+            n_neighbors = num_neighbors, 
+            distance_metric = dist_metr, 
+            aggregate_method = agg_meth,
+            embeddings_type = emb_type,
+            exclude_targets = True,
+            concept = "Q8386"
+        )
+
+        # Get neighbors
+        preds = nn.aggregate_neighbors(method = "nearest")
+
+        # Get neighbors only
+        pred_neighbors = [p[0] for p in preds["aggregated"]]
+
+        # get sensitivity
+        tp = len(set(pred_neighbors) & set(true_neighbors))
+        sensitivity = tp / num_neighbors
+
+        # store results
+        results["EmbeddingType"].append(emb_type)
+        results["AggregationMethod"].append(agg_meth)
+        results["DistanceMetric"].append(dist_metr)
+        results["MedicalCondition"].append(med_cond)
+        results["Sensitivity"].append(sensitivity)
+        results["TruePositive"].append(tp)
+        results["TotalTest"].append(num_neighbors)
+
+    # save results
+    df_results = pd.DataFrame.from_dict(results)
+    df_results.to_csv(args.results_file)
+
+
+if __name__ == "__main__": 
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--drugbank_csv", type=str, default='./DrugBank.csv')
+    parser.add_argument("--num_neighbors", type=int, default=None)
+    parser.add_argument("--emb_file_path", type=str, default='./embeddings.emb')
+    parser.add_argument("--results_file", type=str, default='./drugbank_nn_results.csv')
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
## PR Overview
This PR contains the script for benchmarking NearestNeighbor sensitivity using additional information from DrugBank. 

### Sensitivity analysis
Several medical conditions were randomly selected for our sensitivity analysis, including: 
- ADHD
- Depression 
- Pulmonary Embolism 
- Diabetes
- Hepatitis B
- Heart Attack
- High blood pressure
Drugs used to treat each of these medical conditions were curated from both WikiData and DrugBrank. 

The training (target) and testing (neighbors) set and defined as the following: 
- If a drug appears in both WikiData and DrugBank and has a "treats/is treated by" link between the target medical condition and the drug, it belongs to the training set.
- If the drug appears in both WikiData and DrugBank but does not have a "treats/is treated by" link between condition and drug in our graph, it belongs to the testing set.

The script performs the sensitivity analysis across all combination of *aggregation methods*, *distance metrics*, *embedding methods*, and *medical conditions*.

### Sensitivity calculation
A returned nearest neighbor that is also in the testing set (true neighbors) is considered as **True Positive**

The **sensitivity** is calculated by:  (number of true positive) / (number of returned nearest neighbor)

By default, the number of nearest neighbors to return is set to the number of drugs in the testing set for that medical condition. This number can be changed via the *--num_neighbors* parameter. 

```
Example: 
true_neighbors = [0, 1, 2, 3, 4]
pred_neighbors = [0, 1, 2, 5, 6]
tp == 3
sensitivity == 3/5
```

### Train/test data
The curated training and testing data can be found here: https://docs.google.com/spreadsheets/d/1undvqzV2TZ_pHuOEe6IgCHVvb1s9bnUAHjrDtN62nbQ/edit?usp=sharing